### PR TITLE
ci: pass NPM_TOKEN into the publish step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,5 @@ jobs:
 
       - name: Publish to npm
         run: pnpm publish --access public --tag ${{ steps.dist-tag.outputs.tag }} --no-git-checks --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why this fixes the v0.2.0 publish 404

\`actions/setup-node@v4\` writes \`.npmrc\` with the literal placeholder \`//registry.npmjs.org/:\_authToken=\${NODE_AUTH_TOKEN}\` and **exports \`NODE_AUTH_TOKEN\` itself as the dummy string \`XXXXX-XXXXX-XXXXX-XXXXX\`** so the npmrc parses without an undefined-var error. Without an explicit \`env:\` override on the publish step, pnpm sends that literal dummy string as the auth token and the registry returns \`404 Not Found - PUT https://registry.npmjs.org/@spacecomputer-io%2forbitport-sdk-ts\` (npm's "no permission" response, deliberately disguised as 404). This explains why the failed log shows \`NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX\` even though the new \`NPM_TOKEN\` secret was added — nothing referenced it.

This PR adds the missing \`env:\` block:

\`\`\`yaml
env:
  NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
\`\`\`

## After merging

The existing \`v0.2.0\` tag points at \`4cfb0bd\` which still has the broken workflow, so re-running it won't help. Two options:

1. **Bump to \`v0.2.1\`** (recommended, keeps tag history immutable). The \`v0.2.0\` slot on npm is effectively burned anyway.
2. Force-move the \`v0.2.0\` tag onto post-merge \`main\` and \`git push --force origin v0.2.0\`. Safe because nothing was ever published to npm under that version, but unconventional.

## Test plan

- [ ] Merge this PR
- [ ] Bump to v0.2.1 (or move the tag) and push the tag
- [ ] Confirm the publish step's env block now shows \`NODE_AUTH_TOKEN: ***\` (real masked secret) instead of \`XXXXX-XXXXX-XXXXX-XXXXX\`
- [ ] Verify the package lands on https://www.npmjs.com/package/@spacecomputer-io/orbitport-sdk-ts