### PR TITLE
ci+release: switch to OIDC Trusted Publisher and bump to 0.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
-          registry-url: "https://registry.npmjs.org"
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1] - 2026-05-04
+
+Republish of the 0.2.0 release. The 0.2.0 tag never reached the npm registry — every publish attempt 404'd because `actions/setup-node@v4` was configured with `registry-url`, which made it write a placeholder `.npmrc` and export `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` that pnpm dutifully forwarded to npm. Dropping `registry-url` lets the OIDC trusted-publisher flow take over (see CI workflow change). No SDK behavior change vs 0.2.0.
+
 ## [0.2.0] - 2026-05-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacecomputer-io/orbitport-sdk-ts",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Official TypeScript SDK for SpaceComputer Orbitport",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Switching from token-based publish to OIDC Trusted Publisher and republishing as 0.2.1

Closes the loop on PR #10. Two atomic changes in this PR:

1. **CI fix** (a5ca76c): drop \`registry-url\` from the publish job's \`setup-node\` invocation.
2. **Version bump** (944af28): \`package.json\` 0.2.0 → 0.2.1, with a CHANGELOG entry that explains why we skipped 0.2.0 on npm.

## What \`registry-url\` was doing wrong

When \`actions/setup-node@v4\` is given \`registry-url\`, it writes \`/home/runner/work/_temp/.npmrc\` with the literal placeholder \`//registry.npmjs.org/:\_authToken=\${NODE_AUTH_TOKEN}\` and **exports \`NODE_AUTH_TOKEN\` itself as the dummy string \`XXXXX-XXXXX-XXXXX-XXXXX\`** so the placeholder always resolves. Without an explicit override, pnpm sends that literal dummy string as the auth header → registry returns 404 (npm's deliberate "no permission" response). The OIDC trusted-publisher flow never gets a chance to engage.

Dropping \`registry-url\` keeps \`setup-node\` from touching \`.npmrc\` at all. The publish step then relies entirely on the OIDC token requested at runtime by \`pnpm publish --provenance\`.

## Why bump to 0.2.1

The \`v0.2.0\` tag was pushed but the publish step 404'd every attempt — the package never reached the npm registry. \`v0.2.1\` is a clean republish of the same SDK code with the CI fix. No SDK behavior change vs 0.2.0.

## What's already in place (unchanged)

- \`permissions: id-token: write\` on the publish job ✓
- \`--provenance\` flag on \`pnpm publish\` ✓
- No \`NODE_AUTH_TOKEN\` / \`NPM_TOKEN\` env on the publish step ✓

## Required npm-side config (must be in place before tagging)

On https://www.npmjs.com/package/@spacecomputer-io/orbitport-sdk-ts/access:

1. **Trusted Publisher → Add (or verify):**
   - Publisher: GitHub Actions
   - Organization or user: \`spacecomputer-io\`
   - Repository: \`orbitport-sdk-ts\`
   - **Workflow filename:** \`ci.yml\` *(just the filename — not \`.github/workflows/ci.yml\`; this trips a lot of people up)*
   - **Environment name:** *blank* (the workflow doesn't use \`environment:\`)
2. **Publishing access** → "Require two-factor authentication and disallow tokens".

If the existing Trusted Publisher entry has a different workflow filename or a non-empty environment name, OIDC will fail and the registry will respond with the same 404. Worth double-checking before the next tag push.

## After merging

The pre-existing \`v0.2.1\` tag points at the old \`4cfb0bd\` commit (where \`package.json\` was still 0.2.0 and the CI fix wasn't applied). Delete it and recreate from the merged commit:

\`\`\`bash
git checkout main && git pull
git push origin :refs/tags/v0.2.1   # delete remote
git tag -d v0.2.1                    # delete local
git tag v0.2.1                       # retag at new HEAD
git push origin v0.2.1               # triggers the publish workflow
\`\`\`

## Test plan

- [ ] Verify the npm-side Trusted Publisher fields exactly match the values above
- [ ] Merge this PR
- [ ] Delete the stale \`v0.2.1\` tag locally and on origin, then retag at the merged commit
- [ ] Confirm the publish step no longer shows \`NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX\` in the env block
- [ ] Confirm the package lands on https://www.npmjs.com/package/@spacecomputer-io/orbitport-sdk-ts