### PR TITLE
ci: upgrade npm and use npm publish for OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Upgrade npm for OIDC Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Validate version match
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
@@ -122,4 +125,4 @@ jobs:
         run: pnpm run build
 
       - name: Publish to npm
-        run: pnpm publish --access public --tag ${{ steps.dist-tag.outputs.tag }} --no-git-checks --provenance
+        run: npm publish --access public --tag ${{ steps.dist-tag.outputs.tag }} --provenance


### PR DESCRIPTION
## Summary
- Upgrade npm to latest before the publish step. Node 22 ships with npm 10.x, but [OIDC Trusted Publishing](https://docs.npmjs.com/trusted-publishers) requires npm >= 11.5.1.
- Switch from `pnpm publish` to `npm publish` for the registry call. `pnpm publish` shells out to the bundled (older) npm, which doesn't perform the OIDC token exchange, causing every publish attempt for v0.2.1 to fail with `ENEEDAUTH`.

## Why this is needed
Trusted Publisher is now configured on npmjs for ` @spacecomputer-io/orbitport-sdk-ts`, but until the runner uses npm >= 11.5.1 the publish step keeps prompting for `npm adduser`. This was the failure mode on every v0.2.1 tag push so far.

## Test plan
- [ ] Merge this PR
- [ ] Re-tag v0.2.1 at the new main HEAD and push the tag
- [ ] Confirm the publish job completes successfully and the package appears on npm with provenance