### PR TITLE
ci: bump publish job to Node 24 for npm 11.5+ trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,17 +84,14 @@ jobs:
         with:
           version: latest
 
-      - name: Use Node.js 22.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Upgrade npm for OIDC Trusted Publishing
-        run: npm install -g npm@latest
 
       - name: Validate version match
         run: |


### PR DESCRIPTION
## Summary
- Bump the **publish** job to Node 24.x (test/build stay on Node 22 to match `engines`).
- Drop the `npm install -g npm@latest` step — Node 24 ships with npm 11.5+ out of the box, so we don't need to upgrade in-place.

## Why
The previous fix in #12 tried to upgrade npm to ≥11.5.1 via `npm install -g npm@latest`, but that step itself crashed on the GH runner with `MODULE_NOT_FOUND: Cannot find module 'promise-retry'` — the npm 10.x install bundled with Node 22.22.2 is partially broken on hosted runners and can't always self-upgrade. Bumping the publish job to Node 24 sidesteps the problem entirely: it ships with a working npm 11.5+ that natively supports the OIDC trusted-publisher token exchange.

We don't ship code from the publish job — it just compiles and uploads — so the Node version mismatch with the SDK's `engines` (≥22) is fine.

## Test plan
- [ ] Merge
- [ ] Re-tag v0.2.1 at the new main HEAD and push the tag
- [ ] Confirm the publish job completes and the package appears on npm with provenance attestation