### PR TITLE
fix(kms): always send Description/Tags; surface HTTP error bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.2] - 2026-05-12
+
+### Fixed
+
+- `kms.createKey` now always sends `Description` and `Tags` on the JSON-RPC wire (as `""` / `[]` when the caller omits them). The gateway requires both fields to be present, so the previously-documented minimal payload (`{ alias, keySpec, keyUsage, scheme }`) was rejected with an HTTP 400. `description` and `tags` remain optional in `CreateKeyRequest` — callers need no source change.
+- HTTP error responses now carry the server's response body. `OrbitportSDKError.message` includes the (truncated) body text and `OrbitportSDKError.details.httpBody` holds it verbatim, so plain-text gateway errors such as `Request body deserialize error: missing field` are no longer hidden behind a bare `JSON-RPC HTTP error 400`.
+
+### Changed
+
+- `examples/kms.ts` now passes `description` (and a sample `tags` entry) so the example mirrors a complete request.
+
 ## [0.2.1] - 2026-05-04
 
 Republish of the 0.2.0 release. The 0.2.0 tag never reached the npm registry — every publish attempt 404'd because `actions/setup-node@v4` was configured with `registry-url`, which made it write a placeholder `.npmrc` and export `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` that pnpm dutifully forwarded to npm. Dropping `registry-url` lets the OIDC trusted-publisher flow take over (see CI workflow change). No SDK behavior change vs 0.2.0.

--- a/examples/kms.ts
+++ b/examples/kms.ts
@@ -41,6 +41,8 @@ async function main() {
     keySpec: "AES_256_GCM96",
     keyUsage: "ENCRYPT_DECRYPT",
     scheme: "TRANSIT",
+    description: "SDK example AES key",
+    tags: [{ TagKey: "env", TagValue: "demo" }],
   });
   const aesKeyId = aes.data.KeyMetadata.KeyId;
   const enc = await sdk.kms.encrypt({ keyId: aesKeyId, plaintext: "hello kms" });
@@ -57,6 +59,7 @@ async function main() {
     keySpec: "ECDSA_P256",
     keyUsage: "SIGN_VERIFY",
     scheme: "TRANSIT",
+    description: "SDK example ECDSA P-256 key",
   });
   const sha256OfEmpty = new Uint8Array([
     0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8,
@@ -78,6 +81,7 @@ async function main() {
     keySpec: "ECC_SECG_P256K1",
     keyUsage: "SIGN_VERIFY",
     scheme: "ETHEREUM",
+    description: "SDK example Ethereum key",
   });
   console.log("Address:", eth.data.KeyMetadata.Address);
   const ethSig = await sdk.kms.sign({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spacecomputer-io/orbitport-sdk-ts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Official TypeScript SDK for SpaceComputer Orbitport",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,15 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  minimatch@<3.1.4: 3.1.4
-  minimatch@>=9.0.0 <9.0.7: 9.0.7
-  glob@>=10.2.0: 10.5.0
-  flatted@<3.4.2: 3.4.2
-  picomatch@<2.3.2: 2.3.2
-  picomatch@>=4.0.0 <4.0.4: 4.0.4
-  handlebars@<4.7.9: 4.7.9
-
 importers:
 
   .:
@@ -727,6 +718,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1164,7 +1156,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: 4.0.4
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  unrs-resolver: true

--- a/src/types/kms.ts
+++ b/src/types/kms.ts
@@ -75,7 +75,15 @@ export interface CreateKeyRequest {
   keySpec: KeySpec;
   keyUsage: KeyUsage;
   scheme?: Scheme;
+  /**
+   * Optional human-readable description. Omitted ⇒ sent to the gateway as an
+   * empty string (the field must be present on the wire).
+   */
   description?: string;
+  /**
+   * Optional key tags. Omitted ⇒ sent to the gateway as an empty array (the
+   * field must be present on the wire).
+   */
   tags?: Tag[];
 }
 

--- a/src/utils/jsonrpc.ts
+++ b/src/utils/jsonrpc.ts
@@ -105,7 +105,19 @@ export async function jsonRpcCall<TResult, TParams = Record<string, unknown>>(
     });
 
     if (!response.ok) {
-      throw mapHttpError(response.status, args.url);
+      // Read the response body so callers see the gateway's error text (e.g.
+      // "Request body deserialize error: missing field `Description`"), which
+      // is plain text and never reaches the JSON-RPC error path below.
+      let bodyText = '';
+      try {
+        bodyText = await response.text();
+      } catch {
+        bodyText = '';
+      }
+      if (options.debug && bodyText) {
+        console.log('[OrbitportSDK] JSON-RPC ← HTTP', response.status, bodyText);
+      }
+      throw mapHttpError(response.status, args.url, bodyText);
     }
 
     let body: JsonRpcResponse<TResult>;
@@ -179,39 +191,59 @@ export async function jsonRpcCall<TResult, TParams = Record<string, unknown>>(
   }
 }
 
-function mapHttpError(status: number, url: string): OrbitportSDKError {
+const MAX_HTTP_BODY_IN_ERROR = 2048;
+
+/**
+ * Maps a non-OK HTTP response to a typed OrbitportSDKError.
+ *
+ * When the server sent a (plain-text) body — e.g. a Warp body-deserialization
+ * rejection — it is appended to the message and preserved verbatim in
+ * `error.details.httpBody` so callers can react to it programmatically.
+ */
+function mapHttpError(status: number, url: string, bodyText?: string): OrbitportSDKError {
+  const body = (bodyText ?? '').trim();
+  const truncated =
+    body.length > MAX_HTTP_BODY_IN_ERROR ? `${body.slice(0, MAX_HTTP_BODY_IN_ERROR)}…` : body;
+  const suffix = truncated ? `: ${truncated}` : '';
+  const details = body ? { httpBody: body } : undefined;
+
   if (status === 401 || status === 403) {
     return new OrbitportSDKError(
-      `JSON-RPC authentication failed (HTTP ${status})`,
+      `JSON-RPC authentication failed (HTTP ${status})${suffix}`,
       ERROR_CODES.AUTH_FAILED,
       status,
+      details,
     );
   }
   if (status === 404) {
     return new OrbitportSDKError(
-      `JSON-RPC endpoint not found at ${url}`,
+      `JSON-RPC endpoint not found at ${url}${suffix}`,
       ERROR_CODES.API_ERROR,
       status,
+      details,
     );
   }
   if (status === 429) {
     return new OrbitportSDKError(
-      'JSON-RPC rate limit exceeded',
+      `JSON-RPC rate limit exceeded${suffix}`,
       ERROR_CODES.RATE_LIMITED,
       status,
+      details,
     );
   }
   if (status >= 500) {
     return new OrbitportSDKError(
-      `JSON-RPC service unavailable (HTTP ${status})`,
+      `JSON-RPC service unavailable (HTTP ${status})${suffix}`,
       ERROR_CODES.SERVICE_UNAVAILABLE,
       status,
+      details,
     );
   }
   return new OrbitportSDKError(
-    `JSON-RPC HTTP error ${status}`,
+    `JSON-RPC HTTP error ${status}${suffix}`,
     ERROR_CODES.API_ERROR,
     status,
+    details,
   );
 }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -453,14 +453,18 @@ export function sanitizeCreateKeyRequest(req: CreateKeyRequest): Record<string, 
   }
   const tags = sanitizeTags(req.tags);
 
+  // The gateway requires `Description` and `Tags` to be present on the wire
+  // (they are non-`optional` fields in the proto, so JSON deserialization fails
+  // outright when they are absent). They are still optional in the SDK type —
+  // we normalize them to an empty string / empty array here.
   const params: Record<string, unknown> = {
     Alias: req.alias,
     KeySpec: req.keySpec,
     KeyUsage: req.keyUsage,
+    Description: req.description ?? '',
+    Tags: tags ?? [],
   };
   if (req.scheme !== undefined) params.Scheme = req.scheme;
-  if (req.description !== undefined) params.Description = req.description;
-  if (tags !== undefined) params.Tags = tags;
   return params;
 }
 

--- a/tests/unit/kms.test.ts
+++ b/tests/unit/kms.test.ts
@@ -179,6 +179,38 @@ describe('KMSService — createKey', () => {
     expect(res.data.KeyMetadata.KeyId).toBe('k1');
   });
 
+  it('always sends Description and Tags on the wire even when the caller omits them', async () => {
+    (fetch as jest.Mock).mockImplementationOnce(
+      rpcOk({
+        KeyMetadata: {
+          KeyId: 'k2',
+          Description: '',
+          KeySpec: 'AES_256_GCM96',
+          KeyUsage: 'ENCRYPT_DECRYPT',
+          Enabled: true,
+          PrimaryVersion: 1,
+          CreationDate: 'now',
+          Tags: [],
+          Alias: 'demo-2',
+        },
+      }),
+    );
+    const { svc } = makeService();
+    await svc.createKey({
+      alias: 'demo-2',
+      keySpec: 'AES_256_GCM96',
+      keyUsage: 'ENCRYPT_DECRYPT',
+    });
+
+    expect(lastBody().params).toEqual({
+      Alias: 'demo-2',
+      KeySpec: 'AES_256_GCM96',
+      KeyUsage: 'ENCRYPT_DECRYPT',
+      Description: '',
+      Tags: [],
+    });
+  });
+
   it('uses monotonically increasing JSON-RPC ids across sequential calls', async () => {
     (fetch as jest.Mock)
       .mockImplementationOnce(rpcOk({ Schemes: [] }))
@@ -423,5 +455,40 @@ describe('KMSService — rotateKey + getCapabilities', () => {
     );
     const { svc } = makeService();
     await expect(svc.getCapabilities()).rejects.toBeInstanceOf(OrbitportSDKError);
+  });
+});
+
+describe('KMSService — HTTP error bodies', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('includes the plain-text HTTP 400 body in the thrown error message and details', async () => {
+    const gatewayText = 'Request body deserialize error: missing field `Description`';
+    (fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: false,
+        status: 400,
+        text: async () => gatewayText,
+      } as unknown as Response),
+    );
+    const { svc } = makeService();
+    await expect(
+      svc.createKey({ alias: 'demo', keySpec: 'AES_256_GCM96', keyUsage: 'ENCRYPT_DECRYPT' }),
+    ).rejects.toMatchObject({
+      code: ERROR_CODES.API_ERROR,
+      status: 400,
+      message: expect.stringContaining(gatewayText),
+      details: { httpBody: gatewayText },
+    });
+  });
+
+  it('still throws a typed error when the HTTP error has no readable body', async () => {
+    (fetch as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({ ok: false, status: 503, json: async () => ({}) } as unknown as Response),
+    );
+    const { svc } = makeService();
+    await expect(svc.getCapabilities()).rejects.toMatchObject({
+      code: ERROR_CODES.SERVICE_UNAVAILABLE,
+      status: 503,
+    });
   });
 });


### PR DESCRIPTION
A hackathon participant reported that `sdk.kms.createKey({ alias, keySpec, keyUsage, scheme })` — the shape the SDK type, the SDK example, and the docs all bless — is rejected by the live gateway with HTTP 400 and a plain-text body (`Request body deserialize error: missing field \`Description\``, then `Tags`). The SDK collapsed that into `{"error":"JSON-RPC HTTP error 400","code":"API_ERROR"}` with no body, so they were flying blind.

Root cause: the gateway's `CreateKeyRequest` is generated from `proto/services/kms.proto` where `description` (non-`optional` proto3 `string`) and `tags` (`repeated Tag`) are not `optional`. With prost + serde `PascalCase` and no `#[serde(default)]`, the JSON layer hard-requires both keys. The SDK marked them optional and the sanitizer only forwarded them when present, producing a type-valid request that was an invalid wire request. Separately, `mapHttpError` never read `response.text()`, so any non-JSON-RPC HTTP error was opaque.

## Fix (fully client-side)

- `src/utils/validation.ts` — `sanitizeCreateKeyRequest` now always emits `Description: req.description ?? ''` and `Tags: tags ?? []`. `Scheme` stays conditional (it really is `optional` in the proto).
- `src/utils/jsonrpc.ts` — on `!response.ok`, read the body (guarded `try`/`catch`) and pass it to `mapHttpError(status, url, bodyText)`. The body (≤2 KB) is appended to `message` on every branch and preserved verbatim in `details.httpBody`. Debug logging echoes it.
- `src/types/kms.ts` — `description`/`tags` stay optional (non-breaking); JSDoc notes the SDK fills them with `""` / `[]` on the wire.
- `examples/kms.ts` — examples now show `description` (and a sample `tags` entry).
- `tests/unit/kms.test.ts` — new cases: minimal payload ⇒ wire includes `Description:''`, `Tags:[]`; HTTP 400 body lands in `message` + `details.httpBody`; 503 without a body still types correctly.
- `CHANGELOG.md` + `package.json` → 0.2.2.

## Verification

- `pnpm run type-check`, `pnpm run lint`, `pnpm run build`, `pnpm run test:unit` (136/136) all green.
- Live e2e against `op.spacecomputer.io`: `createKey({ alias, keySpec: 'ECC_SECG_P256K1', keyUsage: 'SIGN_VERIFY', scheme: 'ETHEREUM' })` (minimal payload — previously 400'd) now returns `Description: ""`, `Tags: []`, plus the derived `Address`.

## Follow-up (not in this PR)

The gateway side of complaint #6 — Warp body-deserialize rejections returning plain-text 400 instead of a JSON-RPC error envelope — is mitigated client-side here but worth fixing at the source. A separate issue on `orbitport` could (a) add `#[serde(default)]` field attributes via `gateway/build.rs` so `Description`/`Tags` deserialize cleanly when absent, and (b) wrap Warp body rejections into a `-32600`/`-32602` envelope.